### PR TITLE
Remove link patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,7 @@ Features
 * Send events to flapjack Redis
 * Flapjack JSONAPI
 
-Known bugs
-----------
-* Removing contacts' links with PATCH doesn't work. This is a bug with
-  flapjack. Upon receiving such a request, flapjack returns a 204, but the
-  contact resource remains unchanged.
+Known issues
+------------
+* Flapjack API can return success (204) when it should report fail when
+  removing links with PATCH that don't exist.

--- a/pyflapjack/jsonapi/base.py
+++ b/pyflapjack/jsonapi/base.py
@@ -4,9 +4,11 @@ from .errors import ResourceAttributeError
 
 
 class ResourcePatch(dict):
-    def __init__(self, op, path, value):
+    def __init__(self, op, path, value=None):
         super(ResourcePatch, self).__init__(
-            self, op=op, path=path, value=value)
+            self, op=op, path=path)
+        if value is not None:
+            self['value'] = value
 
 
 class Resource(object):
@@ -47,7 +49,7 @@ class Resource(object):
 
     def remove_link_patch(self, link, oid):
         return ResourcePatch(
-            'remove', '/%s/0/links/%s' % (self.path, link), oid)
+            'remove', '/%s/0/links/%s/%s' % (self.path, link, oid))
 
     def to_dict(self):
         d = {}

--- a/tests/test_api/test_patch.py
+++ b/tests/test_api/test_patch.py
@@ -27,6 +27,5 @@ def test_link_patch(contact):
     patch = contact.remove_link_patch('media', mid)
     assert patch == {
         'op': 'remove',
-        'path': '/contacts/0/links/media',
-        'value': mid
+        'path': '/contacts/0/links/media/' + mid,
     }

--- a/tests/test_api_functional.py
+++ b/tests/test_api_functional.py
@@ -73,17 +73,16 @@ def test_patch_attr(contact):
 
 
 @require_flapjack
-@pytest.mark.xfail(reason='flapjack API bug: patch remove link not working')
 def test_path_link(contact):
     media = Media(
-        type_='sms', address='123@123.com', interval=10, rollup_threshold=10,
+        type='sms', address='123@123.com', interval=10, rollup_threshold=10,
         contact_id=contact.id
     )
     api.create(media)
     new_contact = api.query(Contact, contact.id)[0]
     assert new_contact.media[0] == '%s_%s' % (new_contact.id, 'sms')
     # remove link
-    patch = new_contact.remove_link_patch('media', new_contact.media[0])
+    patch = new_contact.remove_link_patch('media', new_contact.media[0].id)
     api.update(Contact, [patch], new_contact.id)
     new_contact = api.query(Contact, new_contact.id)[0]
     assert len(new_contact.media) == 0


### PR DESCRIPTION
When using PATCH for adding and removing links, the urls used and the JSON content are not the same. These changes handle this difference to make links removal effectively work.